### PR TITLE
Have feature meta data in the geojson

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,15 @@ if (argv.filter && fs.existsSync(argv.filter)) {
 }
 
 var filter = ff(argv.filter);
+var nonProperties = ['lat', 'lon', 'coordinates', 'location'];
 
 stream.on('data', function (data) {
     var f;
     try {
         f = getFeature(data);
+        Object.keys(data).map(function (key) {
+            if (nonProperties.indexOf(key) === -1) f.properties[key] = data[key];
+        });
         if (f && filter(f)) {
             var fc = {
                 'type': 'FeatureCollection',
@@ -31,7 +35,6 @@ stream.on('data', function (data) {
     } catch (e) {
         return;
     }
-
 });
 
 stream.on('end', function() {
@@ -44,7 +47,5 @@ function getFeature(d) {
         'geometry': d.geojson(),
         'properties': d.tags()
     };
-
     return feature;
-
 }


### PR DESCRIPTION
My use-case was extracting new lakes on OpenStreetMap. By new, I mean the feature version is `1`.

---

The feature meta properties are currently not part of the geojson. Ex: For `way/23000626`, we currently get the following properties. Other properties like feature id, feature version, etc are missing.

```json
{
    "name": "Hulimavu Lake",
    "water": "lake",
    "name:kn": "ಹುಳಿಮಾವು ಕೆರೆ",
    "natural": "water"
}
```

With this PR, the properties will be like below for the same feature, `way/23000626`:
```json
{
    "name": "Hulimavu Lake",
    "water": "lake",
    "name:kn": "ಹುಳಿಮಾವು ಕೆರೆ",
    "natural": "water",
    "nodes_count": 49,
    "type": "way",
    "user": "DMANTAMP",
    "uid": 101152,
    "timestamp_seconds_since_epoch": 1476120245,
    "visible": true,
    "changeset": 42782617,
    "version": 9,
    "id": 23000626
}
```

## Uncertainties
- Not sure if all the ^ properties makes sense or is useful to a larger audience.